### PR TITLE
extend /feed with author filtering + deprecate legacy skatesnaps endpoint

### DIFF
--- a/src/app/api/v2/feed/route.ts
+++ b/src/app/api/v2/feed/route.ts
@@ -32,12 +32,13 @@ interface FeedData {
 async function fetchTotal(
   hafDb: HAFSQL_Database,
   community: string,
-  parentPermlink: string
+  parentPermlink: string,
+  author?: string
 ): Promise<number> {
   const tagFilter = `{"tags": ["${community}"]}`;
   console.time('⏱️ HAFSQL COUNT Query');
-  const totalResult = await hafDb.executeQuery(
-    `
+  
+  const query = `
     SELECT COUNT(*) AS total
     FROM comments c
     WHERE 
@@ -49,13 +50,15 @@ async function fetchTotal(
         )
         OR c.parent_permlink = @parent_permlink
       )
+      ${author ? 'AND c.author = @author' : ''}
       AND c.deleted = false;
-    `,
-    [
-      { name: 'tag_filter', value: tagFilter },
-      { name: 'parent_permlink', value: parentPermlink },
-    ]
-  );
+  `;
+
+  const totalResult = await hafDb.executeQuery(query, [
+    { name: 'tag_filter', value: tagFilter },
+    { name: 'parent_permlink', value: parentPermlink },
+    ...(author ? [{ name: 'author', value: author }] : []),
+  ]);
   console.timeEnd('⏱️ HAFSQL COUNT Query');
   return parseInt(totalResult.rows[0].total, 10);
 }
@@ -65,14 +68,14 @@ async function fetchFeedData(
   community: string,
   parentPermlink: string,
   limit: number,
-  offset: number
+  offset: number,
+  author?: string
 ): Promise<FeedData> {
   const tagFilter = `{"tags": ["${community}"]}`;
-  const total = await fetchTotal(hafDb, community, parentPermlink);
+  const total = await fetchTotal(hafDb, community, parentPermlink, author);
 
   console.time('HAFSQL Main Query');
-  const hafRows = await hafDb.executeQuery(
-    `
+  const query = `
     SELECT 
       c.body, c.author, c.permlink, c.parent_author, c.parent_permlink, 
       c.created, c.last_edited, c.cashout_time, c.remaining_till_cashout, c.last_payout, 
@@ -117,6 +120,7 @@ async function fetchFeedData(
         )
         OR c.parent_permlink = @parent_permlink
       )
+      ${author ? 'AND c.author = @author' : ''}
       AND c.deleted = false
     GROUP BY 
       c.body, c.author, c.permlink, c.parent_author, c.parent_permlink, c.created, c.last_edited, c.cashout_time, 
@@ -127,14 +131,15 @@ async function fetchFeedData(
     ORDER BY c.created DESC
     LIMIT @limit
     OFFSET @offset;
-    `,
-    [
-      { name: 'tag_filter', value: tagFilter },
-      { name: 'parent_permlink', value: parentPermlink },
-      { name: 'limit', value: limit },
-      { name: 'offset', value: offset },
-    ]
-  );
+  `;
+
+  const hafRows = await hafDb.executeQuery(query, [
+    { name: 'tag_filter', value: tagFilter },
+    { name: 'parent_permlink', value: parentPermlink },
+    { name: 'limit', value: limit },
+    { name: 'offset', value: offset },
+    ...(author ? [{ name: 'author', value: author }] : []),
+  ]);
   console.timeEnd('HAFSQL Main Query');
 
   const rows = hafRows.rows.map(row => normalizePost(row, 'haf'));
@@ -148,7 +153,8 @@ async function updateCacheInBackground(
   parentPermlink: string,
   limit: number,
   offset: number,
-  cacheKey: string
+  cacheKey: string,
+  author?: string
 ) {
   if (activeUpdates.has(cacheKey)) {
     console.log('Skipping duplicate background update for:', cacheKey);
@@ -157,7 +163,7 @@ async function updateCacheInBackground(
   activeUpdates.add(cacheKey);
   try {
     console.log('Starting background cache update for:', cacheKey);
-    const feedData = await fetchFeedData(hafDb, community, parentPermlink, limit, offset);
+    const feedData = await fetchFeedData(hafDb, community, parentPermlink, limit, offset, author);
     cache.set(cacheKey, { total: feedData.total, rows: feedData.rows, timestamp: Date.now() });
     console.log('Background cache update completed:', cacheKey);
   } catch (error) {
@@ -172,10 +178,11 @@ async function updateCacheInBackground(
 }
 
 export async function GET(request: NextRequest) {
-  console.log('Fetching MAIN FEED data...');
+  console.log('Fetching FEED data...');
 
   const { searchParams } = new URL(request.url);
   const COMMUNITY = searchParams.get('community_code') || process.env.MY_COMMUNITY_CATEGORY || 'hive-173115';
+  const author = searchParams.get('author') || undefined;
   const page = Math.max(1, Number(searchParams.get('page')) || DEFAULT_PAGE);
   const limit = Math.max(1, Number(searchParams.get('limit')) || DEFAULT_FEED_LIMIT);
   const offset = (page - 1) * limit;
@@ -187,7 +194,7 @@ export async function GET(request: NextRequest) {
     console.log(`🔗 Active HAFSQL connections: ${hafDb.getActiveConnections()}`);
     cleanupCache();
 
-    const cacheKey = `feed:${COMMUNITY}:${PARENT_PERMLINK}:${page}:${limit}`;
+    const cacheKey = `feed:${COMMUNITY}:${PARENT_PERMLINK}:${author || 'all'}:${page}:${limit}`;
     const cached = cache.get(cacheKey);
 
     if (cached) {
@@ -196,14 +203,14 @@ export async function GET(request: NextRequest) {
       console.log('📁 Using cached rows:', { rowCount: resultsRows.length });
     } else {
       console.log('Cache miss, fetching data synchronously');
-      const feedData = await fetchFeedData(hafDb, COMMUNITY, PARENT_PERMLINK, limit, offset);
+      const feedData = await fetchFeedData(hafDb, COMMUNITY, PARENT_PERMLINK, limit, offset, author);
       total = feedData.total;
       resultsRows = feedData.rows;
       cache.set(cacheKey, { total, rows: resultsRows, timestamp: Date.now() });
     }
 
     // Schedule background cache update
-    setTimeout(() => updateCacheInBackground(hafDb, COMMUNITY, PARENT_PERMLINK, limit, offset, cacheKey), 0);
+    setTimeout(() => updateCacheInBackground(hafDb, COMMUNITY, PARENT_PERMLINK, limit, offset, cacheKey, author), 0);
 
     console.log('✅ Returning response to client');
     return NextResponse.json({

--- a/src/app/api/v2/skatesnaps/[username]/route.ts
+++ b/src/app/api/v2/skatesnaps/[username]/route.ts
@@ -3,12 +3,13 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { HAFSQL_Database } from '@/lib/hafsql_database';
+import { normalizePost } from '../../feed/helpers';
+import { dealiasSoftPosts } from '@/lib/soft-posts';
 
 const db = new HAFSQL_Database();
 
 const DEFAULT_PAGE = Number(process.env.DEFAULT_PAGE) || 1;
 const DEFAULT_FEED_LIMIT = Number(process.env.DEFAULT_FEED_LIMIT) || 25;
-
 
 export async function GET(
     request: NextRequest,
@@ -37,7 +38,7 @@ export async function GET(
         const total = parseInt(totalRows[0].total);
 
         // Get paginated data
-        const {rows, headers} = await db.executeQuery(`
+        const {rows: hafRows} = await db.executeQuery(`
 SELECT 
     c.body, 
     c.author, 
@@ -69,6 +70,13 @@ SELECT
     c.allow_votes, 
     c.allow_curation_rewards, 
     c.deleted,
+    (
+        SELECT COUNT(*)
+        FROM comments ch
+        WHERE ch.parent_author = c.author
+          AND ch.parent_permlink = c.permlink
+          AND ch.deleted = false
+    ) AS children,
     a.json_metadata AS user_json_metadata, 
     a.reputation, 
     a.followers, 
@@ -137,6 +145,9 @@ LIMIT ${limit}
 OFFSET ${offset};
 `, [{ name: 'username', value: username }]);
 
+        const rows = hafRows.map(row => normalizePost(row, 'haf'));
+        const dealiasedRows = await dealiasSoftPosts(rows);
+
         // Calculate pagination metadata
         const totalPages = Math.ceil(total / limit);
         const hasNextPage = page < totalPages;
@@ -145,8 +156,7 @@ OFFSET ${offset};
         return NextResponse.json(
             {
                 success: true,
-                data: rows,
-                headers: headers,
+                data: dealiasedRows,
                 pagination: {
                     total,
                     totalPages,

--- a/src/app/api/v2/skatesnaps/route.ts
+++ b/src/app/api/v2/skatesnaps/route.ts
@@ -1,5 +1,9 @@
 /*
-  Main Feed 
+ * @deprecated This endpoint is deprecated. Use /api/v2/feed instead.
+ * 
+ * skatesnaps was the original snaps feed using the old container (nxvsjarvmp).
+ * It lacks: children count, post normalization, caching, and parameterized queries.
+ * Kept for backward compatibility only — do NOT use for new integrations.
  */
   import { NextRequest, NextResponse } from 'next/server';
   import { HAFSQL_Database } from '@/lib/hafsql_database';


### PR DESCRIPTION
This PR enhances the `/api/v2/feed` endpoint by adding optional **author-based filtering**, while also marking the legacy `/skatesnaps` endpoint as deprecated.

It improves query flexibility, cache granularity, and aligns newer endpoints with the current feed architecture.

---

### ✨ Changes

#### 1. Author filtering in `/feed`

* Added optional `author` query param:

  ```
  /api/v2/feed?author=username
  ```
* Applies filtering at:

  * total count query
  * main feed query
* Fully parameterized (safe SQL binding)

#### 2. Cache improvements

* Cache key now includes author:

  ```
  feed:{community}:{parent_permlink}:{author|all}:{page}:{limit}
  ```
* Prevents cross-author cache pollution

#### 3. Background updates

* `author` propagated to:

  * `fetchFeedData`
  * `updateCacheInBackground`
* Ensures consistency between cached and fresh data

#### 4. Query refactor

* Extracted SQL queries into variables (`query`)
* Improved readability and maintainability
* Conditional SQL:

  ```sql
  AND c.author = @author
  ```

#### 5. skatesnaps `[username]` improvements

* Added `children` count (reply count per post)
* Fixed query destructuring (`rows` → `hafRows`)
* Applied:

  * `normalizePost`
  * `dealiasSoftPosts`
* Removed unused `headers` return

#### 6. Deprecation notice

* `/api/v2/skatesnaps` is now marked as **deprecated**
* Added clear documentation:

  * points to `/api/v2/feed`
  * explains missing features in legacy endpoint

---

### 🧪 Example usage

**Before**

```
/api/v2/feed?page=1&limit=10
```

**After**

```
/api/v2/feed?page=1&limit=10&author=xvlad
```

---

### ⚠️ Breaking changes

None.

* All changes are backward compatible
* `author` param is optional
* Deprecated endpoints still functional

---

### 🚀 Benefits

* Enables user-specific feeds without extra endpoints
* Improves cache correctness
* Reduces need for client-side filtering
* Moves ecosystem toward `/feed` as the single source of truth

---

### 📝 Notes

* `skatesnaps` kept only for backward compatibility
* New integrations should **only use `/api/v2/feed`**
