### PR TITLE
fix: use service role for leaderboard writes

### DIFF
--- a/src/app/api/cron/v2/dataManager.ts
+++ b/src/app/api/cron/v2/dataManager.ts
@@ -1,5 +1,5 @@
 import { Asset } from '@hiveio/dhive';
-import { supabase } from '../../../utils/supabase/supabaseClient';
+import { supabase, supabaseLeaderboardAdmin } from '../../../utils/supabase/supabaseClient';
 import { logWithColor, fetchAccountInfo, extractEthAddressFromHiveAccount } from '../../../utils/hive/hiveUtils';
 import { fetchDelegatedCurator } from '../../../utils/hive/hiveUtil_hafsql';
 import { DataBaseAuthor } from '../../../utils/types';
@@ -11,6 +11,8 @@ import { matchAndUpsertDonors } from '../../../utils/ethereum/giveth';
 import { fetchCommunityPosts } from '@/app/utils/hive/fetchCommunityPosts';
 import { fetchCommunitySnaps } from '@/app/utils/hive/fetchCommunitySnaps';
 
+const leaderboardTable = process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard';
+const leaderboardWriteClient = supabaseLeaderboardAdmin ?? supabase;
 
 // Helper function to fetch posts and snaps scores from APIs
 async function fetchPostsAndSnapsScore(
@@ -67,7 +69,7 @@ export const removeUnsubscribedAuthors = async (currentSubscribers: { hive_autho
   const currentUsernames = currentSubscribers.map(s => s.hive_author.toLowerCase());
 
   const { data: allAuthors, error } = await supabase
-    .from(process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard')
+    .from(leaderboardTable)
     .select('hive_author');
 
   if (error) {
@@ -83,8 +85,13 @@ export const removeUnsubscribedAuthors = async (currentSubscribers: { hive_autho
     .map(author => author.hive_author);
 
   if (toRemove.length > 0) {
-    const { error: deleteError } = await supabase
-      .from(process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard')
+    if (!leaderboardWriteClient) {
+      logWithColor('Supabase write client not initialized', 'red');
+      return;
+    }
+
+    const { error: deleteError } = await leaderboardWriteClient
+      .from(leaderboardTable)
       .delete()
       .in('hive_author', toRemove);
 
@@ -100,8 +107,8 @@ export const removeUnsubscribedAuthors = async (currentSubscribers: { hive_autho
 
 // Helper function to upsert authors into Supabase
 export const upsertAuthors = async (authors: { hive_author: string }[]) => {
-  if (!supabase) {
-    logWithColor('Supabase client not initialized', 'red');
+  if (!leaderboardWriteClient) {
+    logWithColor('Supabase write client not initialized', 'red');
     return;
   }
 
@@ -110,8 +117,8 @@ export const upsertAuthors = async (authors: { hive_author: string }[]) => {
       hive_author,
     }));
 
-    const { error } = await supabase
-      .from(process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard')
+    const { error } = await leaderboardWriteClient
+      .from(leaderboardTable)
       .upsert(authorData, { onConflict: 'hive_author' });
 
     if (error) {
@@ -127,15 +134,15 @@ export const upsertAuthors = async (authors: { hive_author: string }[]) => {
 
 // Helper function to upsert account data into the leaderboard
 export const upsertAccountData = async (accounts: Partial<DataBaseAuthor>[]) => {
-  if (!supabase) {
-    logWithColor('Supabase client not initialized', 'red');
+  if (!leaderboardWriteClient) {
+    logWithColor('Supabase write client not initialized', 'red');
     return;
   }
 
   try {
     for (const account of accounts) {
-      const { error: upsertError } = await supabase
-        .from(process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard')
+      const { error: upsertError } = await leaderboardWriteClient
+        .from(leaderboardTable)
         .upsert(account, { onConflict: 'hive_author' });
 
       if (upsertError) {
@@ -276,8 +283,8 @@ export const fetchAndUpsertAccountData = async (subscriber: { hive_author: strin
 
 // export const calculateAndUpsertPoints = async () => {
 export const calculateAndUpsertPointsBatch = async (batchUsers: any[]) => {
-  if (!supabase) {
-    logWithColor('Supabase client not initialized', 'red');
+  if (!leaderboardWriteClient) {
+    logWithColor('Supabase write client not initialized', 'red');
     return 0;
   }
 
@@ -475,8 +482,8 @@ export const calculateAndUpsertPointsBatch = async (batchUsers: any[]) => {
     logWithColor(`leaderboardData users = ${leaderboardData.length}`, 'red')
     logWithColor(`users to update = ${usersToUpdate.length}`, 'red')
 
-    const { error } = await supabase
-      .from(process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard')
+    const { error } = await leaderboardWriteClient
+      .from(leaderboardTable)
       .upsert(
         usersToUpdate.map(({ hive_author, points, posts_score }) => ({
           hive_author,
@@ -501,8 +508,8 @@ export const calculateAndUpsertPointsBatch = async (batchUsers: any[]) => {
 
 // Function to calculate and update points for all users
 export const calculateAndUpsertPoints = async () => {
-  if (!supabase) {
-    logWithColor('Supabase client not initialized', 'red');
+  if (!leaderboardWriteClient) {
+    logWithColor('Supabase write client not initialized', 'red');
     return;
   }
 
@@ -614,8 +621,8 @@ export const calculateAndUpsertPoints = async () => {
       return;
     }
 
-    const { error } = await supabase
-      .from(process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard')
+    const { error } = await leaderboardWriteClient
+      .from(leaderboardTable)
       .upsert(
         usersToUpdate.map(({ hive_author, points, post_count }) => ({
           hive_author,
@@ -634,5 +641,4 @@ export const calculateAndUpsertPoints = async () => {
     logWithColor(`Error in calculateAndUpsertPoints: ${(error as Error).message}`, 'red');
   }
 };
-
 

--- a/src/app/utils/ethereum/giveth.ts
+++ b/src/app/utils/ethereum/giveth.ts
@@ -1,8 +1,10 @@
 import { gql, request } from 'graphql-request';
-import { supabase } from '../supabase/supabaseClient';
+import { supabase, supabaseLeaderboardAdmin } from '../supabase/supabaseClient';
 import { logWithColor } from '../hive/hiveUtils';
 
 const GIVETH_API_URL = 'https://mainnet.serve.giveth.io/graphql';
+const leaderboardTable = process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard';
+const leaderboardWriteClient = supabaseLeaderboardAdmin ?? supabase;
 
 const GET_ALL_DONATIONS_BY_PROJECT = gql`
   query GetAllDonationsByProject {
@@ -56,7 +58,7 @@ export const fetchAllHiveAuthors = async () => {
   }
 
   const { data, error } = await supabase
-    .from(process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard')
+    .from(leaderboardTable)
     .select('hive_author, eth_address, giveth_donations_usd, giveth_donations_amount');
 
   if (error) {
@@ -69,9 +71,9 @@ export const fetchAllHiveAuthors = async () => {
 
 /** ✅ Match Giveth donors to existing users or create new ones */
 export const matchAndUpsertDonors = async () => {
-  if (!supabase) {
-    logWithColor('Supabase client not initialized', 'red');
-    throw new Error('Supabase client not initialized');
+  if (!leaderboardWriteClient) {
+    logWithColor('Supabase write client not initialized', 'red');
+    throw new Error('Supabase write client not initialized');
   }
 
   try {
@@ -129,7 +131,7 @@ export const matchAndUpsertDonors = async () => {
 
     // ✅ Bulk upsert aggregated data
     if (upsertData.length > 0) {
-      const { error } = await supabase.from(process.env.NEXT_PUBLIC_SUPABASE_DB || 'leaderboard')
+      const { error } = await leaderboardWriteClient.from(leaderboardTable)
                                       .upsert(upsertData, { 
                                         onConflict: 'hive_author' 
                                       });

--- a/src/app/utils/supabase/supabaseClient.ts
+++ b/src/app/utils/supabase/supabaseClient.ts
@@ -3,6 +3,7 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL_STAGE;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY_STAGE;
+const leaderboardServiceRoleKey = process.env.SUPABASE_LEADERBOARD_SERVICE_ROLE_KEY;
 // Userbase DB (skatehive3.0 Supabase project — separate from the leaderboard DB)
 const userbaseUrl = process.env.SUPABASE_USERBASE_URL || process.env.SUPABASE_URL;
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -12,6 +13,12 @@ const isValidUrl = (url?: string) => url && (url.startsWith('http://') || url.st
 
 export const supabase = (supabaseUrl && isValidUrl(supabaseUrl) && supabaseAnonKey)
   ? createClient(supabaseUrl, supabaseAnonKey)
+  : null;
+
+export const supabaseLeaderboardAdmin = (supabaseUrl && isValidUrl(supabaseUrl) && leaderboardServiceRoleKey)
+  ? createClient(supabaseUrl, leaderboardServiceRoleKey, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    })
   : null;
 
 // Service role client for server-side queries against RLS-protected userbase tables


### PR DESCRIPTION
## Summary
- add a dedicated Supabase admin client for leaderboard writes
- update the leaderboard recompute and Giveth donor writes to use the admin client when configured
- keep public leaderboard reads on the anon client

## Diagnosis
The Mac Mini launchd worker is running, but writes fail against the leaderboard table with RLS errors. The production API still returns 200 with an empty array because the table has no rows.

## Follow-up needed
Add the service role key for the Supabase project referenced by NEXT_PUBLIC_SUPABASE_URL as SUPABASE_LEADERBOARD_SERVICE_ROLE_KEY in Vercel and the Mac Mini .env.local, then run pnpm run recompute:leaderboard.

## Verification
- pnpm exec tsc --noEmit
- pnpm lint
- pnpm build
- pnpm run recompute:leaderboard -- --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced leaderboard infrastructure with improved write operation handling
  * Increased consistency in data mutations across author, account, and points operations
  * Strengthened reliability of leaderboard data processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->