### PR TITLE
fix(leaderboard): never wipe the table when subscriber fetch returns empty

### DIFF
--- a/src/app/api/cron/v2/dataManager.ts
+++ b/src/app/api/cron/v2/dataManager.ts
@@ -66,6 +66,15 @@ export const removeUnsubscribedAuthors = async (currentSubscribers: { hive_autho
     return;
   }
 
+  // Safety guard: an empty subscriber list almost always means the upstream
+  // fetch (HAFSQL community_subs) transiently returned zero rows, NOT that the
+  // community actually lost every member. Proceeding would delete every author
+  // and wipe the leaderboard. Refuse to remove anything in that case.
+  if (!currentSubscribers || currentSubscribers.length === 0) {
+    logWithColor('Refusing to remove authors: subscriber list is empty (likely a transient upstream failure).', 'red');
+    return;
+  }
+
   const currentUsernames = currentSubscribers.map(s => s.hive_author.toLowerCase());
 
   const { data: allAuthors, error } = await supabase

--- a/src/app/api/cron/v2/recompute.ts
+++ b/src/app/api/cron/v2/recompute.ts
@@ -30,6 +30,15 @@ export const updateLeaderboardData = async () => {
         console.warn(`${community} community has ${subscribers.length} subscribers.`);
         console.timeEnd("fetchSubscribers");
 
+        // Abort the recompute if the subscriber fetch came back empty. This is
+        // almost always a transient HAFSQL failure (returns 0 rows without
+        // throwing), and continuing would let removeUnsubscribedAuthors() delete
+        // every author and wipe the leaderboard. Bail out and keep existing data.
+        if (!subscribers || subscribers.length === 0) {
+            logWithColor('Aborting recompute: fetchSubscribers returned 0 subscribers (likely a transient upstream failure). Leaderboard left untouched.', 'red');
+            return;
+        }
+
         console.time("getLeaderboard");
         var leaderboardData = await getLeaderboard();
         console.warn(`Leaderboard has ${leaderboardData.length} records.`);


### PR DESCRIPTION
## Problem
The leaderboard page renders "0 skaters" because the Supabase `leaderboard` table was wiped (0 rows). `api.skatehive.app/api/v2/leaderboard` correctly returns `[]`.

## Root cause
The Mac Mini recompute job → `updateLeaderboardData()` calls `removeUnsubscribedAuthors(subscribers)`, which deletes every author not in the subscriber list. That list comes from `fetchSubscribers()`, a HAFSQL `community_subs` query that **returns an empty array without throwing** when it transiently hits zero rows. When that happens, `toRemove` becomes every non-`donator_` row and the entire table gets deleted.

Confirmed the Hive community (`hive-173115`) still has 100+ subscribers, so this was a transient upstream blip, not real membership loss.

## Fix (defense in depth)
- `recompute.ts`: abort the whole recompute if `fetchSubscribers()` returns 0, leaving existing data untouched.
- `dataManager.ts`: `removeUnsubscribedAuthors` refuses to delete anything when the subscriber list is empty.

## Repopulation
The table still needs one recompute run to refill (handled separately on the Mac Mini); these guards prevent recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)