### PR TITLE
feat(userbase): comment beneficiaries + app-tag passthrough

### DIFF
--- a/src/app/api/userbase/hive/comment/route.ts
+++ b/src/app/api/userbase/hive/comment/route.ts
@@ -38,12 +38,36 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ success: false, error: "Posting not available" }, { status: 500 });
   }
 
+  const incoming =
+    body?.json_metadata && typeof body.json_metadata === "object"
+      ? (body.json_metadata as Record<string, unknown>)
+      : {};
   const metadata: Record<string, unknown> = {
-    ...(body?.json_metadata && typeof body.json_metadata === "object" ? body.json_metadata : {}),
-    app: "skatehive-mobile",
+    ...incoming,
+    app: typeof incoming.app === "string" ? incoming.app : "skatehive-mobile",
   };
   const safe = getSafeUserIdentifier(userId);
   if (safe) metadata.skatehive_user = safe;
+
+  // Beneficiaries (reward split) — mirror the web route's validation rules so a
+  // proxied web comment keeps its comment_options instead of dropping them.
+  const rawBenef = Array.isArray(body?.beneficiaries) ? body.beneficiaries : [];
+  let beneficiaries: Array<{ account: string; weight: number }> = [];
+  if (rawBenef.length > 0) {
+    const total = rawBenef.reduce((s: number, b: any) => s + Number(b?.weight || 0), 0);
+    if (total > 10000) {
+      return NextResponse.json({ success: false, error: "Beneficiaries exceed 100%" }, { status: 400 });
+    }
+    beneficiaries = rawBenef
+      .filter(
+        (b: any) =>
+          b?.account &&
+          typeof b.account === "string" &&
+          /^[a-z][a-z0-9.-]{2,15}$/.test(b.account) &&
+          Number(b?.weight) > 0
+      )
+      .map((b: any) => ({ account: b.account, weight: Number(b.weight) }));
+  }
 
   try {
     await broadcastComment(signer, {
@@ -53,6 +77,7 @@ export async function POST(req: NextRequest) {
       title,
       body: content,
       jsonMetadata: metadata,
+      beneficiaries,
     });
   } catch (e) {
     console.error("[userbase/hive/comment] broadcast", e);
@@ -72,6 +97,7 @@ export async function POST(req: NextRequest) {
         title,
         body: content,
         safe_user: safe,
+        beneficiaries: beneficiaries.length > 0 ? beneficiaries : undefined,
       },
     }).catch((e) => console.error("[userbase/hive/comment] soft-post", e));
   }

--- a/src/lib/userbase/posting.ts
+++ b/src/lib/userbase/posting.ts
@@ -58,20 +58,48 @@ export async function broadcastComment(
     title: string;
     body: string;
     jsonMetadata: Record<string, unknown>;
+    beneficiaries?: Array<{ account: string; weight: number }>;
   }
 ): Promise<void> {
-  await HiveClient.broadcast.comment(
-    {
-      parent_author: opts.parentAuthor,
-      parent_permlink: opts.parentPermlink,
-      author: signer.author,
-      permlink: opts.permlink,
-      title: opts.title,
-      body: opts.body,
-      json_metadata: JSON.stringify(opts.jsonMetadata),
-    },
-    PrivateKey.fromString(signer.key)
-  );
+  const ops: any[] = [
+    [
+      "comment",
+      {
+        parent_author: opts.parentAuthor,
+        parent_permlink: opts.parentPermlink,
+        author: signer.author,
+        permlink: opts.permlink,
+        title: opts.title,
+        body: opts.body,
+        json_metadata: JSON.stringify(opts.jsonMetadata),
+      },
+    ],
+  ];
+  if (opts.beneficiaries && opts.beneficiaries.length > 0) {
+    ops.push([
+      "comment_options",
+      {
+        author: signer.author,
+        permlink: opts.permlink,
+        max_accepted_payout: "1000000.000 HBD",
+        percent_hbd: 10000,
+        allow_votes: true,
+        allow_curation_rewards: true,
+        extensions: [
+          [
+            0,
+            {
+              beneficiaries: opts.beneficiaries.map((b) => ({
+                account: b.account,
+                weight: b.weight,
+              })),
+            },
+          ],
+        ],
+      },
+    ]);
+  }
+  await HiveClient.broadcast.sendOperations(ops, PrivateKey.fromString(signer.key));
 }
 
 // Generic custom_json broadcast signed with posting authority (follow, mute,


### PR DESCRIPTION
## What
The userbase `comment` route now:
- broadcasts a `comment_options` op with **beneficiaries** when provided (reward split), via `broadcastComment` in `posting.ts`;
- **respects an incoming `json_metadata.app`** instead of hardcoding `skatehive-mobile` (defaults to `skatehive-mobile` when absent).

## Why
Phase 2 of the userbase unification: the web `hive/comment` route will proxy to this api endpoint. Without these two changes, proxied web comments would (a) lose their beneficiaries and (b) be mislabeled `skatehive-mobile`.

## Compatibility
Fully backward compatible — no beneficiaries → single `comment` op (as before); no `app` sent → `skatehive-mobile` (mobile unchanged).

## Verification
- `tsc --noEmit`: clean.
- Post-merge: post a comment with a beneficiary via Bearer (mobile) → on-chain `comment_options` present; `app` defaults to `skatehive-mobile`; one soft-post row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment submissions now support optional beneficiaries, allowing a share of rewards to be assigned when posting.
  * Comment metadata now includes app identification and a user identifier when available.

* **Bug Fixes**
  * Added validation to reject invalid beneficiary totals and filter out malformed entries.
  * Beneficiary details are only included when at least one valid recipient remains, reducing malformed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->