### PR TITLE
fix(userbase): comment honors body.type for soft-post (snap fidelity)

### DIFF
--- a/src/app/api/userbase/hive/comment/route.ts
+++ b/src/app/api/userbase/hive/comment/route.ts
@@ -89,7 +89,12 @@ export async function POST(req: NextRequest) {
       author: signer.author,
       permlink,
       title,
-      type: parentAuthor ? "comment" : "post",
+      type:
+        typeof body?.type === "string" && ["post", "comment", "snap"].includes(body.type)
+          ? body.type
+          : parentAuthor
+          ? "comment"
+          : "post",
       metadata: {
         onchain: metadata,
         parent_author: parentAuthor,


### PR DESCRIPTION
Proxied web snaps send `type:snap`; api was hardcoding comment/post, miscategorizing the soft_post (profile 'snaps' filter). Now honors a valid `body.type` (post/comment/snap), else the prior default. Mobile unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how post types are recorded for incoming comments and posts.
  * The app now respects an explicitly provided content type when it is valid, while still falling back to the existing post/comment logic when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->