### PR TITLE
refactor(api): standardize userbase auth on resolveUserbaseUserId

### DIFF
--- a/src/app/api/userbase/auth/session/route.ts
+++ b/src/app/api/userbase/auth/session/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getBearerUserId, getUserPublic } from "@/lib/userbase/session";
+import { resolveUserbaseUserId, getUserPublic } from "@/lib/userbase/session";
 
 export const runtime = "nodejs";
 
 // Validate a bearer session token → current user.
 export async function GET(req: NextRequest) {
-  const userId = await getBearerUserId(req);
+  const userId = await resolveUserbaseUserId(req);
   if (!userId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/userbase/hive/account-update/route.ts
+++ b/src/app/api/userbase/hive/account-update/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getBearerUserId } from "@/lib/userbase/session";
+import { resolveUserbaseUserId } from "@/lib/userbase/session";
 import { resolveSigner, broadcastAccountUpdate } from "@/lib/userbase/posting";
 import { HiveClient } from "@/app/utils/hive/hiveUtils";
 
@@ -15,7 +15,7 @@ export const runtime = "nodejs";
 // unedited fields intact even when the client's merge-base was wrong/empty
 // (e.g. a userbase handle that differs from the on-chain account).
 export async function POST(req: NextRequest) {
-  const userId = await getBearerUserId(req);
+  const userId = await resolveUserbaseUserId(req);
   if (!userId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/userbase/hive/comment/route.ts
+++ b/src/app/api/userbase/hive/comment/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getBearerUserId } from "@/lib/userbase/session";
+import { resolveUserbaseUserId } from "@/lib/userbase/session";
 import { resolveSigner, broadcastComment, recordSoftPost } from "@/lib/userbase/posting";
 import { getSafeUserIdentifier } from "@/lib/userbase/safeUser";
 
@@ -13,7 +13,7 @@ function genPermlink(): string {
 // user's stored key, or the shared @skateuser account for lite accounts —
 // recording attribution + embedding the safe-user id for the feed overlay.
 export async function POST(req: NextRequest) {
-  const userId = await getBearerUserId(req);
+  const userId = await resolveUserbaseUserId(req);
   if (!userId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/userbase/hive/follow/route.ts
+++ b/src/app/api/userbase/hive/follow/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getBearerUserId } from "@/lib/userbase/session";
+import { resolveUserbaseUserId } from "@/lib/userbase/session";
 import { resolveSigner, broadcastCustomJson } from "@/lib/userbase/posting";
 
 export const runtime = "nodejs";
@@ -7,7 +7,7 @@ export const runtime = "nodejs";
 // Follow/mute on behalf of a userbase user (server signs with their own stored
 // key). Disallowed for lite accounts on the shared @skateuser account.
 export async function POST(req: NextRequest) {
-  const userId = await getBearerUserId(req);
+  const userId = await resolveUserbaseUserId(req);
   if (!userId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/userbase/hive/notifications/route.ts
+++ b/src/app/api/userbase/hive/notifications/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getBearerUserId } from "@/lib/userbase/session";
+import { resolveUserbaseUserId } from "@/lib/userbase/session";
 import { resolveSigner, broadcastCustomJson } from "@/lib/userbase/posting";
 
 export const runtime = "nodejs";
@@ -8,7 +8,7 @@ export const runtime = "nodejs";
 // their behalf. Requires the user's own Hive account — the shared @skateuser
 // account's notifications must never be touched, and lite accounts have none.
 export async function POST(req: NextRequest) {
-  const userId = await getBearerUserId(req);
+  const userId = await resolveUserbaseUserId(req);
   if (!userId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/userbase/hive/report/route.ts
+++ b/src/app/api/userbase/hive/report/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getBearerUserId } from "@/lib/userbase/session";
+import { resolveUserbaseUserId } from "@/lib/userbase/session";
 import { resolveSigner, broadcastCustomJson } from "@/lib/userbase/posting";
 
 export const runtime = "nodejs";
@@ -9,7 +9,7 @@ export const runtime = "nodejs";
 // endpoint performs no encryption — it just receives the already-built
 // custom_json content and broadcasts it under the user's posting authority.
 export async function POST(req: NextRequest) {
-  const userId = await getBearerUserId(req);
+  const userId = await resolveUserbaseUserId(req);
   if (!userId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/userbase/hive/upload-image/route.ts
+++ b/src/app/api/userbase/hive/upload-image/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import crypto from "crypto";
 import { PrivateKey } from "@hiveio/dhive";
-import { getBearerUserId } from "@/lib/userbase/session";
+import { resolveUserbaseUserId } from "@/lib/userbase/session";
 import { resolveSigner } from "@/lib/userbase/posting";
 
 export const runtime = "nodejs";
@@ -11,7 +11,7 @@ export const runtime = "nodejs";
 // Hive image-upload challenge with the user's key — or the shared @skateuser
 // account — and uploads to images.hive.blog, returning the public URL.
 export async function POST(req: NextRequest) {
-  const userId = await getBearerUserId(req);
+  const userId = await resolveUserbaseUserId(req);
   if (!userId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }

--- a/src/app/api/userbase/hive/vote/route.ts
+++ b/src/app/api/userbase/hive/vote/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getBearerUserId } from "@/lib/userbase/session";
+import { resolveUserbaseUserId } from "@/lib/userbase/session";
 import { resolveSigner, broadcastVote, recordSoftVote } from "@/lib/userbase/posting";
 import { getSafeUserIdentifier } from "@/lib/userbase/safeUser";
 
@@ -8,7 +8,7 @@ export const runtime = "nodejs";
 // Vote on behalf of a userbase user (server signs with their stored key, or the
 // shared @skateuser account for lite accounts).
 export async function POST(req: NextRequest) {
-  const userId = await getBearerUserId(req);
+  const userId = await resolveUserbaseUserId(req);
   if (!userId) {
     return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
   }


### PR DESCRIPTION
Swap getBearerUserId -> resolveUserbaseUserId (dual Bearer/cookie) across userbase routes. Additive; Bearer path unchanged; removes auth-pattern inconsistency vs instagram routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)