### PR TITLE
perf(api): cache highest-paid via CDN-Cache-Control (spike)

### DIFF
--- a/src/app/api/v2/highest-paid/route.ts
+++ b/src/app/api/v2/highest-paid/route.ts
@@ -148,7 +148,13 @@ export async function GET(request: NextRequest) {
             }
         }, {
             headers: {
-                'Cache-Control': 's-maxage=300, stale-while-revalidate=600',
+                // Next.js strips s-maxage from DYNAMIC route handlers' Cache-Control
+                // (this route reads searchParams), forcing max-age=0 at the CDN. Drive the
+                // Vercel edge cache with CDN-Cache-Control / Vercel-CDN-Cache-Control, which
+                // are passed through untouched. Browser still revalidates (max-age=0).
+                'Cache-Control': 'public, max-age=0, must-revalidate',
+                'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=600',
+                'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=600',
                 'X-Cache-Source': cacheSource,
                 'X-Execution-Time': `${executionTime}ms`
             }


### PR DESCRIPTION
Spike: drive Vercel edge cache for a dynamic route handler via CDN-Cache-Control (Next strips s-maxage from dynamic handlers). Measure x-vercel-cache HIT, then roll out to other reads. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated caching behavior for the highest-paid API response to improve freshness while still allowing efficient CDN delivery.
  * Responses will now revalidate more reliably, helping reduce stale data for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->