### PR TITLE
perf(api): edge-cache all v2 reads via CDN-Cache-Control

### DIFF
--- a/src/app/api/v2/balance/[username]/route.ts
+++ b/src/app/api/v2/balance/[username]/route.ts
@@ -53,7 +53,7 @@ export async function GET(
       {
         status: 200,
         headers: {
-          'Cache-Control': 's-maxage=60, stale-while-revalidate=30'
+          'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=60, stale-while-revalidate=30', 'Vercel-CDN-Cache-Control': 's-maxage=60, stale-while-revalidate=30'
         }
       }
     );

--- a/src/app/api/v2/blacklisted/[username]/route.ts
+++ b/src/app/api/v2/blacklisted/[username]/route.ts
@@ -47,7 +47,7 @@ LIMIT 1000 OFFSET ${validOffset};
             {
                 status: 200,
                 headers: {
-                    'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                    'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                 }
             }
         );

--- a/src/app/api/v2/feed/[username]/following/route.ts
+++ b/src/app/api/v2/feed/[username]/following/route.ts
@@ -167,7 +167,7 @@ export async function GET(
             {
                 status: 200,
                 headers: {
-                    'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                    'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                 }
             }
         );

--- a/src/app/api/v2/feed/[username]/route.ts
+++ b/src/app/api/v2/feed/[username]/route.ts
@@ -159,7 +159,7 @@ OFFSET ${offset};
             {
                 status: 200,
                 headers: {
-                    'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                    'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                 }
             }
         );

--- a/src/app/api/v2/feed/route.ts
+++ b/src/app/api/v2/feed/route.ts
@@ -231,7 +231,7 @@ export async function GET(request: NextRequest) {
     }, {
       status: 200,
       headers: {
-        'Cache-Control': 's-maxage=300, stale-while-revalidate=150',
+        'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150',
       },
     });
 

--- a/src/app/api/v2/feed/trending/route.ts
+++ b/src/app/api/v2/feed/trending/route.ts
@@ -153,7 +153,7 @@ export async function GET(request: NextRequest) {
       {
         status: 200,
         headers: {
-          'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+          'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
         }
       }
     );

--- a/src/app/api/v2/followers/[username]/route.ts
+++ b/src/app/api/v2/followers/[username]/route.ts
@@ -47,7 +47,7 @@ export async function GET(
             {
                 status: 200,
                 headers: {
-                    'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                    'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                 }
             }
         );

--- a/src/app/api/v2/following/[username]/route.ts
+++ b/src/app/api/v2/following/[username]/route.ts
@@ -49,7 +49,7 @@ export async function GET(
             {
                 status: 200,
                 headers: {
-                    'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                    'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                 }
             }
         );

--- a/src/app/api/v2/leaderboard/route.ts
+++ b/src/app/api/v2/leaderboard/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
         const data = await getLeaderboard();
         return NextResponse.json(data, {
             headers: {
-                'Cache-Control': 's-maxage=500, stale-while-revalidate=300'
+                'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=500, stale-while-revalidate=300', 'Vercel-CDN-Cache-Control': 's-maxage=500, stale-while-revalidate=300'
             }
         });
     } catch (error) {

--- a/src/app/api/v2/market/route.ts
+++ b/src/app/api/v2/market/route.ts
@@ -38,7 +38,7 @@ export async function GET(
       {
         status: 200,
         headers: {
-          'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+          'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
         }
       }
     );

--- a/src/app/api/v2/muted/[username]/route.ts
+++ b/src/app/api/v2/muted/[username]/route.ts
@@ -47,7 +47,7 @@ LIMIT 1000 OFFSET ${validOffset};
             {
                 status: 200,
                 headers: {
-                    'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                    'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                 }
             }
         );

--- a/src/app/api/v2/posting-status/route.ts
+++ b/src/app/api/v2/posting-status/route.ts
@@ -71,7 +71,7 @@ export async function GET(request: NextRequest) {
       { 
         status: 200,
         headers: {
-          'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30'
+          'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30', 'Vercel-CDN-Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30'
         }
       }
     );

--- a/src/app/api/v2/profile/[username]/route.ts
+++ b/src/app/api/v2/profile/[username]/route.ts
@@ -104,7 +104,7 @@ export async function GET(
       {
         status: 200,
         headers: {
-          'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+          'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
         }
       }
     );

--- a/src/app/api/v2/profile/route.ts
+++ b/src/app/api/v2/profile/route.ts
@@ -102,7 +102,7 @@ export async function GET(request: NextRequest) {
       {
         status: 200,
         headers: {
-          'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+          'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
         }
       }
     );

--- a/src/app/api/v2/search/route.ts
+++ b/src/app/api/v2/search/route.ts
@@ -146,7 +146,7 @@ export async function GET(request: NextRequest) {
       }
     }, {
         headers: {
-            'Cache-Control': 's-maxage=60, stale-while-revalidate=30'
+            'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=60, stale-while-revalidate=30', 'Vercel-CDN-Cache-Control': 's-maxage=60, stale-while-revalidate=30'
         }
     });
 

--- a/src/app/api/v2/skatesnaps/[username]/following/route.ts
+++ b/src/app/api/v2/skatesnaps/[username]/following/route.ts
@@ -170,7 +170,7 @@ export async function GET(
             {
                 status: 200,
                 headers: {
-                    'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                    'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                 }
             }
         );

--- a/src/app/api/v2/skatesnaps/[username]/route.ts
+++ b/src/app/api/v2/skatesnaps/[username]/route.ts
@@ -171,7 +171,7 @@ OFFSET ${offset};
             {
                 status: 200,
                 headers: {
-                    'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                    'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                 }
             }
         );

--- a/src/app/api/v2/skatesnaps/route.ts
+++ b/src/app/api/v2/skatesnaps/route.ts
@@ -163,7 +163,7 @@
         }, 
         { status: 200,
           headers: {
-              'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+              'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
           } }
       );
     } catch (error) {

--- a/src/app/api/v2/skatesnaps/trending/route.ts
+++ b/src/app/api/v2/skatesnaps/trending/route.ts
@@ -160,7 +160,7 @@
               {
                   status: 200,
                   headers: {
-                      'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+                      'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
                   }
               }
           );

--- a/src/app/api/v2/skatespots/route.ts
+++ b/src/app/api/v2/skatespots/route.ts
@@ -159,7 +159,7 @@
         }, 
         { status: 200,
           headers: {
-              'Cache-Control': 's-maxage=300, stale-while-revalidate=150'
+              'Cache-Control': 'public, max-age=0, must-revalidate', 'CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150', 'Vercel-CDN-Cache-Control': 's-maxage=300, stale-while-revalidate=150'
           } }
       );
     } catch (error) {


### PR DESCRIPTION
Follow-up to the highest-paid spike (#33, confirmed HIT). Applies CDN-Cache-Control/Vercel-CDN-Cache-Control to the 20 other v2 read routes so their intended s-maxage actually reaches the Vercel edge (Next strips it from dynamic handlers). Mirrors existing TTLs. Excludes videos/route.ts (in-flight WIP). 🤖 Generated with [Claude Code](https://claude.com/claude-code)