### PR TITLE
feat(api): include rshares per vote in /api/v2/videos

### DIFF
--- a/src/app/api/v2/videos/route.ts
+++ b/src/app/api/v2/videos/route.ts
@@ -46,7 +46,8 @@ async function fetchVideoPostsBatch(
         json_agg(
           json_build_object(
             'voter', v.voter,
-            'weight', v.weight
+            'weight', v.weight,
+            'rshares', v.rshares
           )
         ) FILTER (WHERE v.id IS NOT NULL),
         '[]'


### PR DESCRIPTION
Adds `rshares` to each vote object in the videos response (source view `operation_effective_comment_vote_view` has the column). tsc clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video vote data returned by the API now includes an additional vote score field, so vote details are more complete in video post responses.
  * Improved consistency in the video list endpoint by carrying this extra vote information through to the final output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->